### PR TITLE
Update the terraform plugin executable path with correct `v` in name

### DIFF
--- a/terraform-provider-conjur.rb
+++ b/terraform-provider-conjur.rb
@@ -18,7 +18,7 @@ class TerraformProviderConjur < Formula
   depends_on "terraform"
 
   def install
-    bin.install "terraform-provider-conjur_0.3.1"
+    bin.install "terraform-provider-conjur_v0.3.1"
   end
 
   def caveats; <<~EOS
@@ -38,6 +38,6 @@ class TerraformProviderConjur < Formula
 
   test do
     # Running bin directly gives error, exit code 1
-    system "#{bin}/terraform-provider-conjur_0.3.1", "-h"
+    system "#{bin}/terraform-provider-conjur_v0.3.1", "-h"
   end
 end


### PR DESCRIPTION
Original brew recipe didn't have the correct executable name so the
test/installation was failing. This change fixes that issue.