### PR TITLE
Updated terraform plugin to point to v0.4.0

### DIFF
--- a/terraform-provider-conjur.rb
+++ b/terraform-provider-conjur.rb
@@ -2,23 +2,23 @@
 class TerraformProviderConjur < Formula
   desc "Terraform provider for CyberArk Conjur"
   homepage "https://github.com/cyberark/terraform-provider-conjur"
-  version "0.3.1"
+  version "0.4.0"
   bottle :unneeded
 
   if OS.mac?
-    url "https://github.com/cyberark/terraform-provider-conjur/releases/download/v0.3.1/terraform-provider-conjur-0.3.1-darwin-amd64.tar.gz"
-    sha256 "7802f2e93bc923ccce02d37b370e36dc5dadc62ff01c2dffb5f2420c4d8da5eb"
+    url "https://github.com/cyberark/terraform-provider-conjur/releases/download/v0.4.0/terraform-provider-conjur-0.4.0-darwin-amd64.tar.gz"
+    sha256 "616327d3c4c8ae15918f081f7ef7a4862b2d72070b4a7a39257854fbc5b97cf8"
   elsif OS.linux?
     if Hardware::CPU.intel?
-      url "https://github.com/cyberark/terraform-provider-conjur/releases/download/v0.3.1/terraform-provider-conjur-0.3.1-linux-amd64.tar.gz"
-      sha256 "c1b64bc9618c7dacb6677a977d7b863a353ef0ed42380672cce0e65d359d4137"
+      url "https://github.com/cyberark/terraform-provider-conjur/releases/download/v0.4.0/terraform-provider-conjur-0.4.0-linux-amd64.tar.gz"
+      sha256 "9489f6315fcbb4e56e539dd85a129b315ecf9acce840cf904171c7cba4aa4636"
     end
   end
   
   depends_on "terraform"
 
   def install
-    bin.install "terraform-provider-conjur_v0.3.1"
+    bin.install "terraform-provider-conjur_v0.4.0"
   end
 
   def caveats; <<~EOS
@@ -32,12 +32,12 @@ class TerraformProviderConjur < Formula
     rm -f  ~/.terraform.d/plugins/terraform-provider-conjur
     
     # Symlink the provider to your home dir. If Homebrew is installing somewhere other than /usr/local/Cellar, update the path as well.
-    ln -sf /usr/local/Cellar/terraform-provider-conjur/0.3.1/bin/terraform-provider-conjur_v0.3.1 ~/.terraform.d/plugins/terraform-provider-conjur_v0.3.1
+    ln -sf /usr/local/Cellar/terraform-provider-conjur/0.4.0/bin/terraform-provider-conjur_v0.4.0 ~/.terraform.d/plugins/terraform-provider-conjur_v0.4.0
   EOS
   end
 
   test do
     # Running bin directly gives error, exit code 1
-    system "#{bin}/terraform-provider-conjur_v0.3.1", "-h"
+    system "#{bin}/terraform-provider-conjur_v0.4.0", "-h"
   end
 end


### PR DESCRIPTION
Since we have a new release of this plugin, we need to update our brew
recipes.