### PR TITLE
Updated summon to version v0.8.3

### DIFF
--- a/summon.rb
+++ b/summon.rb
@@ -2,16 +2,16 @@
 class Summon < Formula
   desc "CLI that provides on-demand secrets access for common DevOps tools."
   homepage "https://github.com/cyberark/summon"
-  version "0.8.2"
+  version "0.8.3"
   bottle :unneeded
 
   if OS.mac?
-    url "https://github.com/cyberark/summon/releases/download/v0.8.2/summon-darwin-amd64.tar.gz"
-    sha256 "50c474e50cb2ab94dcc96ed77df7184b1029fa4c5650006120c856c2137e2b84"
+    url "https://github.com/cyberark/summon/releases/download/v0.8.3/summon-darwin-amd64.tar.gz"
+    sha256 "6c6e06970ba1f38dbdbe1169b355f796f11cd3b06e53584fab93b264d5e02201"
   elsif OS.linux?
     if Hardware::CPU.intel?
-      url "https://github.com/cyberark/summon/releases/download/v0.8.2/summon-linux-amd64.tar.gz"
-      sha256 "57e47674c52687db6e015915b8a2e3d58adcd624b4ba1a887b10a7395de6d8aa"
+      url "https://github.com/cyberark/summon/releases/download/v0.8.3/summon-linux-amd64.tar.gz"
+      sha256 "fc0e0feaf6ef4fb641a41762a2c76d1a282fec3f852e1141af6e3f8ab24f074f"
     end
   end
 


### PR DESCRIPTION
This PR updates our homebrew version of summon from 0.8.2 to 0.8.3