### PR TITLE
Remove Deprecated bottle: unneeded

### DIFF
--- a/terraform-provider-conjur.rb
+++ b/terraform-provider-conjur.rb
@@ -6,7 +6,6 @@ class TerraformProviderConjur < Formula
   desc "Terraform provider for CyberArk Conjur"
   homepage "https://github.com/cyberark/terraform-provider-conjur"
   version "0.6.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Installing summon fails with brew 3.4.1 with the following error:

```
Error: Invalid formula: /Users/redacted/homebrew/Library/Taps/cyberark/homebrew-tools/terraform-provider-conjur.rb
terraform-provider-conjur: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the cyberark/tools tap (not Homebrew/brew or Homebrew/core):
  /Users/redacted/homebrew/Library/Taps/cyberark/homebrew-tools/terraform-provider-conjur.rb:9
```

This commit removes the offending deprecated property.
