### PR TITLE
Fix summon-aws-secrets install URLs

### DIFF
--- a/summon-aws-secrets.rb
+++ b/summon-aws-secrets.rb
@@ -9,7 +9,7 @@ class SummonAwsSecrets < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/cyberark/summon/releases/download/v0.4.1/summon-aws-secrets-darwin-amd64.tar.gz"
+      url "https://github.com/cyberark/summon-aws-secrets/releases/download/v0.4.1/summon-aws-secrets-darwin-amd64.tar.gz"
       sha256 "8ea2d42eaba79153f12c1b2c0f2394ed51d5f4448f0f666a903556ac032fe036"
 
       def install
@@ -18,7 +18,7 @@ class SummonAwsSecrets < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/cyberark/summon/releases/download/v0.4.1/summon-aws-secrets-darwin-arm64.tar.gz"
+      url "https://github.com/cyberark/summon-aws-secrets/releases/download/v0.4.1/summon-aws-secrets-darwin-arm64.tar.gz"
       sha256 "ccdc5c20cb0d08d13aba4e21deeb98b5dcf0457af36e25c7e269758db801661e"
 
       def install
@@ -30,7 +30,7 @@ class SummonAwsSecrets < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/cyberark/summon/releases/download/v0.4.1/summon-aws-secrets-linux-amd64.tar.gz"
+      url "https://github.com/cyberark/summon-aws-secrets/releases/download/v0.4.1/summon-aws-secrets-linux-amd64.tar.gz"
       sha256 "9c560625a48c2350b1cdfa2c3fb645d145f9b2913a3ef06eafc3e6770ccc87ad"
 
       def install


### PR DESCRIPTION
### Desired Outcome

Install URLs pointed to `summon` releases instead of `summon-aws-secrets` releases.

### Implemented Changes

Updated URLs to point to `summon-aws-secrets` releases.
Fixed URL template in project's GoReleaser config in [summon-aws-secrets#61](https://github.com/cyberark/summon-aws-secrets/pull/61).

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
