### PR TITLE
Update secretless-broker to v1.7.16

### DIFF
--- a/secretless-broker.rb
+++ b/secretless-broker.rb
@@ -5,20 +5,20 @@
 class SecretlessBroker < Formula
   desc "Secures your apps by making them Secretless"
   homepage "https://secretless.io"
-  version "1.7.14"
+  version "1.7.16"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/cyberark/secretless-broker/releases/download/v1.7.14/secretless-broker_1.7.14_darwin_arm64.tar.gz"
-      sha256 "2562e4b988a9819cba2cd4f22ab2b20567ce393e1f2b0719704713e9df700e33"
+      url "https://github.com/cyberark/secretless-broker/releases/download/v1.7.16/secretless-broker_1.7.16_darwin_arm64.tar.gz"
+      sha256 "e3dba30dbecab39aefdef8b23e6e8d68af34519b69247fe5c34b5deed98a652f"
 
       def install
         bin.install "secretless-broker"
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/cyberark/secretless-broker/releases/download/v1.7.14/secretless-broker_1.7.14_darwin_amd64.tar.gz"
-      sha256 "5f263686d5c1fa5bb1343c7922e82e55d22d0ee91609769a941da85273aa8a6f"
+      url "https://github.com/cyberark/secretless-broker/releases/download/v1.7.16/secretless-broker_1.7.16_darwin_amd64.tar.gz"
+      sha256 "f8fee7d52e658b5fd936f566e2dde699824a4555a612e02e1c8427d2163f9b93"
 
       def install
         bin.install "secretless-broker"
@@ -28,8 +28,8 @@ class SecretlessBroker < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/cyberark/secretless-broker/releases/download/v1.7.14/secretless-broker_1.7.14_linux_amd64.tar.gz"
-      sha256 "9bd44ed1f8080a723ed7a28070e309573a89caccb8093d4f56aa9f4ecb35ace9"
+      url "https://github.com/cyberark/secretless-broker/releases/download/v1.7.16/secretless-broker_1.7.16_linux_amd64.tar.gz"
+      sha256 "98805e253f47f62a49663cbd8068fb2afe65549dd919891189f849a8fe641254"
 
       def install
         bin.install "secretless-broker"


### PR DESCRIPTION
### Desired Outcome

Update Secretless Broker to [v1.7.16](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.16).

### Implemented Changes

Updated `secretless-broker.rb` release URLs and artifact signatures.

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
