### PR TITLE
Update summon and summon-conjur

### DIFF
--- a/summon-conjur.rb
+++ b/summon-conjur.rb
@@ -5,12 +5,12 @@
 class SummonConjur < Formula
   desc "Conjur provider for Summon"
   homepage "https://github.com/cyberark/summon-conjur"
-  version "0.7.0"
+  version "0.7.1"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/cyberark/summon-conjur/releases/download/v0.7.0/summon-conjur-darwin-amd64.tar.gz"
-      sha256 "236acbe38d4b18ac5438199d255cce872b22b3f5163a490064fbeaafcd1e0297"
+      url "https://github.com/cyberark/summon-conjur/releases/download/v0.7.1/summon-conjur-darwin-amd64.tar.gz"
+      sha256 "04f5972275b0f3c647d13e4b288050c5f6e61d27cfc8e3dfb965e81f771d2ec1"
 
       def install
         target = lib/"summon"
@@ -18,8 +18,8 @@ class SummonConjur < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/cyberark/summon-conjur/releases/download/v0.7.0/summon-conjur-darwin-arm64.tar.gz"
-      sha256 "d2a25b22f08809e369570646c9785a83d13e1afecc1a45b1ecb896485400ea83"
+      url "https://github.com/cyberark/summon-conjur/releases/download/v0.7.1/summon-conjur-darwin-arm64.tar.gz"
+      sha256 "cc68edf30529379422998e8b118bb11c613aaedc54380945413290f3245874a5"
 
       def install
         target = lib/"summon"
@@ -30,8 +30,8 @@ class SummonConjur < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/cyberark/summon-conjur/releases/download/v0.7.0/summon-conjur-linux-amd64.tar.gz"
-      sha256 "fb203aeea3b0341ff9adcb39bb7b0959580763e092388874fdd42870f2bd63ed"
+      url "https://github.com/cyberark/summon-conjur/releases/download/v0.7.1/summon-conjur-linux-amd64.tar.gz"
+      sha256 "4187364b7178d18a6f47c68d0c95eaeb308ce711f550890da39bf25d8184ce44"
 
       def install
         target = lib/"summon"

--- a/summon.rb
+++ b/summon.rb
@@ -5,20 +5,20 @@
 class Summon < Formula
   desc "CLI that provides on-demand secrets access for common DevOps tools."
   homepage "https://github.com/cyberark/summon"
-  version "0.9.5"
+  version "0.9.6"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/cyberark/summon/releases/download/v0.9.5/summon-darwin-arm64.tar.gz"
-      sha256 "a0b33a5c7f7eda03907da5526dcde64e45a50d2c220ee0b9504107acbb83db89"
+      url "https://github.com/cyberark/summon/releases/download/v0.9.6/summon-darwin-arm64.tar.gz"
+      sha256 "ce22eb0e22bdc1514c7c39370db92d9e1b4bd8688f7d5e8ccc26a90ca5807e5d"
 
       def install
         bin.install "summon"
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/cyberark/summon/releases/download/v0.9.5/summon-darwin-amd64.tar.gz"
-      sha256 "9b4ed03fb04361cdeb22c89876b756e02c5c486e42afd5405d404c6c80451bc5"
+      url "https://github.com/cyberark/summon/releases/download/v0.9.6/summon-darwin-amd64.tar.gz"
+      sha256 "644c8671630d4dd233220c070afcb900a43c551256bec5171146c00cc944ccfc"
 
       def install
         bin.install "summon"
@@ -28,8 +28,8 @@ class Summon < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/cyberark/summon/releases/download/v0.9.5/summon-linux-amd64.tar.gz"
-      sha256 "f5d120176b75eb3f7e42963b26e0fdc0e434383b9943c8d43a11073ee4c0c13f"
+      url "https://github.com/cyberark/summon/releases/download/v0.9.6/summon-linux-amd64.tar.gz"
+      sha256 "fd071cec433bcfe537cf6e7742527369eb908f6c9471c755544c52b2512ab4ac"
 
       def install
         bin.install "summon"


### PR DESCRIPTION
- Update summon version to v0.9.6. Release notes are available at https://github.com/cyberark/summon/releases/tag/v0.9.6
- Update summon-conjur version to v0.7.1. Release notes are available at https://github.com/cyberark/summon-conjur/releases/tag/v0.7.1