### PR TITLE
Update secretless-broker to 1.7.19

### DIFF
--- a/secretless-broker.rb
+++ b/secretless-broker.rb
@@ -5,20 +5,20 @@
 class SecretlessBroker < Formula
   desc "Secures your apps by making them Secretless"
   homepage "https://secretless.io"
-  version "1.7.17"
+  version "1.7.19"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/cyberark/secretless-broker/releases/download/v1.7.17/secretless-broker_1.7.17_darwin_arm64.tar.gz"
-      sha256 "a158e88ff7e4b9f2318bebde31510d2294421ac915e8cfa98a1f4049ece69de5"
+      url "https://github.com/cyberark/secretless-broker/releases/download/v1.7.19/secretless-broker_1.7.19_darwin_arm64.tar.gz"
+      sha256 "cc63b5bdbc75a596419911c61705f813c44b905f2afb37900cce82473c85cc77"
 
       def install
         bin.install "secretless-broker"
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/cyberark/secretless-broker/releases/download/v1.7.17/secretless-broker_1.7.17_darwin_amd64.tar.gz"
-      sha256 "7af615a2dbced1510f99b25542ed0ebc08af2c9bc04f081545ff75addbcdf83b"
+      url "https://github.com/cyberark/secretless-broker/releases/download/v1.7.19/secretless-broker_1.7.19_darwin_amd64.tar.gz"
+      sha256 "ab6db06e985a28074699d11c680d58873aa07e66f621e878a24b8d8f5ce3bc81"
 
       def install
         bin.install "secretless-broker"
@@ -28,8 +28,8 @@ class SecretlessBroker < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/cyberark/secretless-broker/releases/download/v1.7.17/secretless-broker_1.7.17_linux_amd64.tar.gz"
-      sha256 "897002ff14b5dedf70d735b7465db53c2e1e8caf723a318d9802551139700170"
+      url "https://github.com/cyberark/secretless-broker/releases/download/v1.7.19/secretless-broker_1.7.19_linux_amd64.tar.gz"
+      sha256 "720978b8df9355ea4bce59af5f447a222bfe82307bf285092677ce4c4280af5e"
 
       def install
         bin.install "secretless-broker"


### PR DESCRIPTION
Update secretless-broker version to 1.7.19. See [release notes](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.19)